### PR TITLE
Update to AWS SDK V3

### DIFF
--- a/aws-ssh.gemspec
+++ b/aws-ssh.gemspec
@@ -11,5 +11,6 @@ Gem::Specification.new do |gem|
   gem.executables   = ['aws-ssh', 'awssh']
 
   gem.add_dependency  'slop', '~> 4'
-  gem.add_dependency  'aws-sdk', '~> 2'
+  gem.add_dependency  'aws-sdk-ec2', '~> 1'
+  gem.add_dependency  'nokogiri', '>= 1.11.0'
 end

--- a/bin/aws-ssh
+++ b/bin/aws-ssh
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'slop'
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 require 'yaml'
 
 module AWSSSH


### PR DESCRIPTION
- AWS SDK has been modularized into smaller gems in Version 3. This uses
only aws-sdk-ec2.
- V2 fails on Ruby 3.0.1 due to a webrick dependency
- V3 requires an XML gem, nokogiri was added, requiring the earliest
version with no known security vulnerabilities

Tested on ruby 2.5.5, 2.7.2 and 3.0.1